### PR TITLE
Jetpack and Material Design Components conversion complete

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,5 +44,6 @@ dependencies {
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha2'
     androidTestImplementation 'androidx.test:runner:1.1.0-alpha2'
+    androidTestImplementation 'androidx.test:rules:1.1.0-alpha2'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha2'
 }

--- a/app/src/androidTest/java/com/designdemo/uaha/DeviceListTest.java
+++ b/app/src/androidTest/java/com/designdemo/uaha/DeviceListTest.java
@@ -1,17 +1,18 @@
 package com.designdemo.uaha;
 
 
-import androidx.test.espresso.ViewInteraction;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
-import androidx.test.suitebuilder.annotation.LargeTest;
-
 import com.designdemo.uaha.ui.MainActivity;
 import com.support.android.designlibdemo.R;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -20,7 +21,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.core.AllOf.allOf;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -31,6 +32,7 @@ public class DeviceListTest {
 
     @Test
     public void deviceListTest() {
+
         ViewInteraction appCompatTextView = onView(
                 allOf(withText("Device"), isDisplayed()));
         appCompatTextView.perform(click());

--- a/app/src/androidTest/java/com/designdemo/uaha/VersionListTest.java
+++ b/app/src/androidTest/java/com/designdemo/uaha/VersionListTest.java
@@ -2,9 +2,10 @@ package com.designdemo.uaha;
 
 
 import androidx.test.espresso.ViewInteraction;
+//import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
-import androidx.test.suitebuilder.annotation.LargeTest;
+//import androidx.test.suitebuilder.annotation.LargeTest;
 
 import com.designdemo.uaha.ui.MainActivity;
 import com.support.android.designlibdemo.R;
@@ -22,9 +23,10 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static org.hamcrest.Matchers.allOf;
 
-@LargeTest
+//@LargeTest
 @RunWith(AndroidJUnit4.class)
 public class VersionListTest {
+
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);

--- a/app/src/main/res/layout/fragment_prod_list.xml
+++ b/app/src/main/res/layout/fragment_prod_list.xml
@@ -11,6 +11,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"
         xmlns:android="http://schemas.android.com/apk/res/android"
+        android:paddingBottom="48dp"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 


### PR DESCRIPTION
This will fix the tests, and finishes the conversion to using the new Jetpack and Material Design Components libraries.

Needed to add an dependency to Gradle, then add additional static imports to my Espresso test class.  But now the tests are enabled and passing again, so all is GREEN!